### PR TITLE
86 stage canvas

### DIFF
--- a/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.js
+++ b/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.js
@@ -484,18 +484,17 @@ export default function AnnotationDrawing({
   /** */
   const drawKonvas = () => (
     <Stage
-      width={width}
-      height={height}
+      width={playerReferences.getDisplayedImageWidth()}
+      height={playerReferences.getDisplayedImageHeight()}
       style={{
         height: 'auto',
-        left: 0,
+        left: playerReferences.getImagePosition().x,
         objectFit: 'contain',
         overflow: 'clip',
         overflowClipMargin: 'content-box',
         position: 'absolute',
-        top: 0,
-        width: '100%',
-        border: '10px solid black',
+        top: playerReferences.getImagePosition().y,
+        backgroundColor: 'rgba(0, 0, 255, 0.5)',
       }}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}

--- a/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.js
+++ b/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.js
@@ -506,7 +506,7 @@ export default function AnnotationDrawing({
         onShapeClick={onShapeClick}
         activeTool={toolState.activeTool}
         selectedShapeId={drawingState.currentShape?.id}
-        scale={scale}
+        scale={playerReferences.getZoom()}
         onTransform={onTransform}
         handleDragEnd={handleDragEnd}
         handleDragStart={handleDragStart}

--- a/src/playerReferences.js
+++ b/src/playerReferences.js
@@ -65,13 +65,9 @@ export const playerReferences = (function () {
       if (_mediaType === mediaTypes.IMAGE) {
         const viewer = _media.current;
         if (viewer && viewer.world.getItemCount() > 0) {
-          // Assuming one image in OpenSeadragon for now
-          const tiledImage = viewer.world.getItemAt(0);
-          const contentSize = tiledImage.getContentSize();
-          const percentageWidth = contentSize.x * viewer.viewport.getZoom();
+          const percentageWidth = _canvases[0].__jsonld.width * viewer.viewport.getZoom();
           const containerWidth = viewer.container.clientWidth;
           const actualWidthInPixels = Math.round(containerWidth * percentageWidth);
-          console.log('df actualWidthInPixels', actualWidthInPixels);
           return actualWidthInPixels;
         }
       }
@@ -80,23 +76,20 @@ export const playerReferences = (function () {
     getDisplayedImageHeight() {
       if (_mediaType === mediaTypes.IMAGE) {
         const viewer = _media.current;
-        if (viewer && viewer.world.getItemCount() > 0) {
-          // Assuming one image in OpenSeadragon for now
-          const tiledImage = viewer.world.getItemAt(0);
-          const contentSize = tiledImage.getContentSize();
-          const percentageHeight = contentSize.y * viewer.viewport.getZoom();
+        if (viewer) {
+          const percentageHeight = _canvases[0].__jsonld.height * viewer.viewport.getZoom();
           const containerWidth = viewer.container.clientWidth;
           const actualHeightInPixels = Math.round(containerWidth * percentageHeight);
-          console.log('df actualHeightInPixels', actualHeightInPixels);
           return actualHeightInPixels;
         }
       }
       return undefined;
     },
     getImagePosition() {
+      // TODO: Index off the IIIF canvas instead of the first image
       if (_mediaType === mediaTypes.IMAGE) {
         const viewer = _media.current;
-        if (viewer && viewer.world.getItemCount() > 0) {
+        if (viewer) {
           // Assuming one image in OpenSeadragon for now
           const tiledImage = viewer.world.getItemAt(0);
           // Get the bounds of the image in viewport coordinates
@@ -108,7 +101,6 @@ export const playerReferences = (function () {
             x: Math.round(topLeft.x),
             y: Math.round(topLeft.y)
           };
-          console.log('df Image position in pixels:', position);
           return position;
         }
       }

--- a/src/playerReferences.js
+++ b/src/playerReferences.js
@@ -68,6 +68,7 @@ export const playerReferences = (function () {
           const percentageWidth = _canvases[0].__jsonld.width * viewer.viewport.getZoom();
           const containerWidth = viewer.container.clientWidth;
           const actualWidthInPixels = Math.round(containerWidth * percentageWidth);
+          console.log('df actualWidthInPixels', actualWidthInPixels);
           return actualWidthInPixels;
         }
       }
@@ -80,6 +81,7 @@ export const playerReferences = (function () {
           const percentageHeight = _canvases[0].__jsonld.height * viewer.viewport.getZoom();
           const containerWidth = viewer.container.clientWidth;
           const actualHeightInPixels = Math.round(containerWidth * percentageHeight);
+          console.log('df actualHeightInPixels', actualHeightInPixels);
           return actualHeightInPixels;
         }
       }
@@ -103,6 +105,17 @@ export const playerReferences = (function () {
           };
           return position;
         }
+      }
+      return undefined;
+    },
+    getZoom() {
+      if (_mediaType === mediaTypes.IMAGE) {
+        const zoom = _media.current.viewport.getZoom();
+        const canvasWidth = _canvases[0].__jsonld.width;
+        const canvasHeight = _canvases[0].__jsonld.height;
+        const greaterDimension = Math.max(canvasWidth, canvasHeight);
+        const naturalZoom = zoom * greaterDimension;
+        return naturalZoom;
       }
       return undefined;
     },

--- a/src/playerReferences.js
+++ b/src/playerReferences.js
@@ -61,6 +61,59 @@ export const playerReferences = (function () {
       }
       return undefined;
     },
+    getDisplayedImageWidth() {
+      if (_mediaType === mediaTypes.IMAGE) {
+        const viewer = _media.current;
+        if (viewer && viewer.world.getItemCount() > 0) {
+          // Assuming one image in OpenSeadragon for now
+          const tiledImage = viewer.world.getItemAt(0);
+          const contentSize = tiledImage.getContentSize();
+          const percentageWidth = contentSize.x * viewer.viewport.getZoom();
+          const containerWidth = viewer.container.clientWidth;
+          const actualWidthInPixels = Math.round(containerWidth * percentageWidth);
+          console.log('df actualWidthInPixels', actualWidthInPixels);
+          return actualWidthInPixels;
+        }
+      }
+      return undefined;
+    },
+    getDisplayedImageHeight() {
+      if (_mediaType === mediaTypes.IMAGE) {
+        const viewer = _media.current;
+        if (viewer && viewer.world.getItemCount() > 0) {
+          // Assuming one image in OpenSeadragon for now
+          const tiledImage = viewer.world.getItemAt(0);
+          const contentSize = tiledImage.getContentSize();
+          const percentageHeight = contentSize.y * viewer.viewport.getZoom();
+          const containerWidth = viewer.container.clientWidth;
+          const actualHeightInPixels = Math.round(containerWidth * percentageHeight);
+          console.log('df actualHeightInPixels', actualHeightInPixels);
+          return actualHeightInPixels;
+        }
+      }
+      return undefined;
+    },
+    getImagePosition() {
+      if (_mediaType === mediaTypes.IMAGE) {
+        const viewer = _media.current;
+        if (viewer && viewer.world.getItemCount() > 0) {
+          // Assuming one image in OpenSeadragon for now
+          const tiledImage = viewer.world.getItemAt(0);
+          // Get the bounds of the image in viewport coordinates
+          const bounds = tiledImage.getBounds();
+          // Convert the top-left corner of the bounds to pixel coordinates
+          const topLeft = viewer.viewport.viewportToViewerElementCoordinates(bounds.getTopLeft());
+          // Round the coordinates for consistency
+          const position = {
+            x: Math.round(topLeft.x),
+            y: Math.round(topLeft.y)
+          };
+          console.log('df Image position in pixels:', position);
+          return position;
+        }
+      }
+      return undefined;
+    },
     init(state, windowId, playerRef, actions) {
       _canvases = getVisibleCanvases(state, { windowId });
       _mediaType = _canvases[0].__jsonld.items ? mediaTypes.VIDEO : mediaTypes.IMAGE;


### PR DESCRIPTION
I'm only opening the PR for discussion.

This locks the Konva `<Stage>` size to the IIIF canvas size. It positions the `<Stage>` relative to the first image in the OSD `world`.

I'm not sure this is the right approach, but all others I have tried have not worked.

There is still something wrong with the scaling of annotations when comparing the Konva rendering (create and edit views) and Mirador's rendering. The coords at 0,0 are correct but become increasingly offset in both the x and y axis.