### PR TITLE
Add exports for ES module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dist"
   ],
   "exports": {
-    "./src": "./src/index.js"
+    "./src": "./src/index.js",
+    ".": {
+      "import": "./dist/mirador-annotation-editor.es.js"
+     }
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
See https://github.com/vitejs/vite/issues/15405

This addresses a bug where importing an rpm-installed mirador-annotation-editor results in the error
```
  ✘ [ERROR] Failed to resolve entry for package "mirador-annotation-editor". The package may have incorrect main/module/exports specified in its package.json: Missing "." specifier in "mirador-annotation-editor" package [plugin vite:dep-scan]

    script:/Users/andy/Documents/github/dl-viewer/src/components/MiradorViewer.vue?id=0:5:30:
      5 │ import annotationPlugins from 'mirador-annotation-editor'
        ╵                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

It probably also needs an exports["."]["require"] line but I haven't tested that