### PR TITLE
Various fixes

### DIFF
--- a/src/IIIFUtils.js
+++ b/src/IIIFUtils.js
@@ -65,7 +65,7 @@ const getIIIFTargetFullCanvas = (maeData, canvasId) => {
  */
 const getIIIFTargetFromRectangleShape = (maeTarget, canvasId, shape) => {
   console.info('Implement target as string with one shape (rectangle)');
-  const {
+  let {
     x,
     y,
     width,
@@ -73,6 +73,19 @@ const getIIIFTargetFromRectangleShape = (maeTarget, canvasId, shape) => {
     scaleX,
     scaleY,
   } = shape;
+
+  // if `width` or `height` may be negative if the annotation was not created by dragging from the top left.
+  // convert to ensure that x and y always describe the top-left corner of an annotation and that
+  // `width` and `height` are positive.
+  // (can be useful to use xywh in Cantaloupe, for example).
+  if ( width < 0 ) {
+    width = -width;
+    x = x-width;
+  }
+  if ( height < 0 ) {
+    height = -height;
+    y = y-height;
+  }
 
   // Image have not tstart and tend
   // We use scaleX and scaleY to have the real size of the shape, if it has been resized
@@ -400,7 +413,6 @@ export function convertIIIFAnnoToMaeData(anno) {
 
       maeData.target = convertIIIFTargetToMae(anno.target, anno.id);
       anno.maeData = maeData;
-      console.log("!!!anno", anno);
       return anno;
     } catch (e) {
       console.error('Error generating maeData from annotation', e);

--- a/src/IIIFUtils.js
+++ b/src/IIIFUtils.js
@@ -230,19 +230,35 @@ const svgToXywh = (svgDoc) => {
 
 /**
  * generate a string-representation of an SVG rectangle based on XYWH coordinates
- * @param {{ x: number, y: number, w: number, fullW: number?, fullH: number? }}
+ * @param {{ x: number|string, y: number|string, w: number|string, fullW: number|string|undefined, fullH: number|string|undefined }}
  * @returns {string}
  */
 const xywhToSvg = ({
   x, y, w, h, fullW = undefined, fullH = undefined,
-}) => `<svg
+}) => {
+  // retype just in case
+  x = parseFloat(x);
+  y = parseFloat(y);
+  w = parseFloat(w);
+  h = parseFloat(h);
+  if (fullH) {
+    fullH = parseFloat(fullH);
+  } else if (fullW) {
+    fullW = parseFloat(fullW);
+  }
+  const svgWh =
+    fullW && fullH
+      ? `width='${fullW}' height='${fullH}'`
+      : '';
+  if ( [x,y,w,h].some(val => typeof val !== "number") ) {
+    throw new Error(`xywhToSvg: x,y,w,h must be floats (got x=${x}, y=${y}, w=${w}, h=${h})`)
+  }
+
+  return `<svg
       version='1.1'
       xmlns='http://www.w3.org/2000/svg'
       xmlns:xlink='http://www.w3.org/1999/xlink'
-      ${fullW && fullH
-    ? `width='${fullW}' height='${fullH}'`
-    : ''
-}
+      ${svgWh}
   >
     <defs/>
     <g><g>
@@ -256,17 +272,19 @@ const xywhToSvg = ({
         stroke-dasharray=''
       />
     </g></g>
-  </svg>`;
+  </svg>`
+};
 
 const convertFragmentSelectorToMae = (selector) => {
-  const [x, y, w, h] = selector.value.replace('xywh=', '').split(',');
+  // NOTE: parseFloat is VERY important. without it, when modifying annotation, it will be displayed VERY weirdly.
+  const [x, y, w, h] = selector.value.replace('xywh=', '').split(',').map(parseFloat);
   const currentShape = {
     id: uuidv4(),
     rotation: 0,
     scaleX: 1,
     scaleY: 1,
-    x,
-    y,
+    x: x,
+    y: y,
     width: w,
     height: h,
     type: SHAPES_TOOL.RECTANGLE,
@@ -352,6 +370,7 @@ const convertIIIFTargetToMae = (target, annotationId) => {
         return convertFragmentSelectorToMae(selector);
       }
     } catch (err) {
+      console.error(`Error generating maeData from selector ${selector.type}, attempting to fallback to other selector`, err);
     }
   }
   // if at the end of the loop, no selector could be processed, log an error and return.
@@ -381,6 +400,7 @@ export function convertIIIFAnnoToMaeData(anno) {
 
       maeData.target = convertIIIFTargetToMae(anno.target, anno.id);
       anno.maeData = maeData;
+      console.log("!!!anno", anno);
       return anno;
     } catch (e) {
       console.error('Error generating maeData from annotation', e);

--- a/src/annotationAdapter/AiiinotateAdapter.js
+++ b/src/annotationAdapter/AiiinotateAdapter.js
@@ -221,8 +221,6 @@ export default class AiiinotateAdapter {
     let r;
     let rBody;  // annotationList / annotationPage.
 
-    console.log("HELLO !");
-
     while ( nextPage && nextPage.length ) {
       r = await fetch(this.annotationPageId);
       rBody = await r.json();

--- a/src/annotationAdapter/AiiinotateAdapter.js
+++ b/src/annotationAdapter/AiiinotateAdapter.js
@@ -220,6 +220,9 @@ export default class AiiinotateAdapter {
     let nextPage = this.annotationPageId;
     let r;
     let rBody;  // annotationList / annotationPage.
+
+    console.log("HELLO !");
+
     while ( nextPage && nextPage.length ) {
       r = await fetch(this.annotationPageId);
       rBody = await r.json();


### PR DESCRIPTION
hello @geourjoa ! this is a small PR with minor fixes that were detected when modifying in MAE annotations created outside of MAE (in AIKON). changes were tested in MAE and in AIKON using the MAE builds created with `npm run build`. 

## 1. `getIIIFTargetFromRectangleShape`

ensure that the `x,y` in `x,y,width,height` is always the top-left corner, and that `width` and `height` are always positive-or-null. the advantages are:
- consistency
- easier integration: if you want to use a FragmentSelector (`#xywh=...`) to build an URI using the IIIF Image API, `x`, `y`, `width`, `height` must always be positive (in Cantaloupe, a negative width is an error)

## 2. `xywhToSvg` and `convertFragmentSelectorToMae`

`x`, `y`, `w`, `h` are now parsed to float. otherwise, they are strings, which leads to weird bugs when editing an annotation created outside of MAE, where `convertIIIFAnnoToMae` (i.e., handles not being editable...)

**PS**: I documented the structure of `maeData` and where it is modified [here](https://github.com/paulhectork/halp/blob/main/mae.md), do you think it would be useful to add to MAE's Wiki ? 
