### PR TITLE
[UI] Hotkeys and default URL search params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log*
 .*.sw?
 /dist
 out
+.DS_Store

--- a/src/CanvasListItem.jsx
+++ b/src/CanvasListItem.jsx
@@ -14,6 +14,7 @@ import { useTranslation, withTranslation } from 'react-i18next';
 import InfoIcon from '@mui/icons-material/Info';
 import AnnotationActionsContext from './AnnotationActionsContext';
 import WhoAndWhenFormSection, { TOOLTIP_MODE } from './annotationForm/WhoAndWhenFormSection';
+import HotkeyTooltip from "./hotkeys/HotkeyTooltip";
 
 // TODO missing TRAD
 const CanvasListItem = forwardRef((props, ref) => {
@@ -188,7 +189,7 @@ const CanvasListItem = forwardRef((props, ref) => {
                 </span>
               </Tooltip>,
 
-              <Tooltip title={t('deleteAnnotation')} key="delete">
+              <Tooltip title={<HotkeyTooltip label={t('deleteAnnotation')} action="delete" />} key="delete">
                 <span>
                   <ToggleButton
                     aria-label="Delete"

--- a/src/SingleCanvasDialog.jsx
+++ b/src/SingleCanvasDialog.jsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import HotkeyTooltip from "./hotkeys/HotkeyTooltip";
 
 /**
  * Dialog to enforce single view for annotation creation / editing
@@ -51,7 +52,7 @@ function SingleCanvasDialog({ handleClose, open, switchToSingleCanvasView }) {
       </DialogContent>
 
       <DialogActions>
-        <Tooltip title={t('cancel')}>
+        <Tooltip title={<HotkeyTooltip label={t('cancel')} action="escape" />}>
           <Button onClick={handleClose}>{t('cancel')}</Button>
         </Tooltip>
         <Tooltip title={t('switch_view')}>

--- a/src/annotationForm/AnnotationForm.jsx
+++ b/src/annotationForm/AnnotationForm.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useReducer, useState } from 'react';
+import React, {
+  useCallback, useEffect, useReducer, useRef, useState,
+} from 'react';
 import { ConnectedCompanionWindow } from 'mirador';
 import PropTypes from 'prop-types';
 import { Grid } from '@mui/material';
@@ -13,6 +15,7 @@ import AnnotationFormHeader from './AnnotationFormHeader';
 import AnnotationFormBody from './AnnotationFormBody';
 import '../custom.css';
 import UnsupportedMedia from './UnsupportedMedia';
+import { MAE_ANNOTATION_EMPTY_EVENT } from '../hotkeys/hotkeysEvents';
 
 /**
  * Component for submitting a form to create or edit an annotation.
@@ -34,7 +37,7 @@ function AnnotationForm(
   // eslint-disable-next-line no-underscore-dangle
   const [mediaType, setMediaType] = useState(playerReferences.getMediaType());
 
-  // TDOO perhaps useless
+  // TODO perhaps useless
   const [retryCount, setRetryCount] = useState(0);
 
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
@@ -111,12 +114,38 @@ function AnnotationForm(
    *
    * @returns {void}
    */
-  const closeFormCompanionWindow = () => {
+  const closeFormCompanionWindow = useCallback(() => {
     closeCompanionWindow('annotationCreation', {
       id,
       position: 'right',
     });
-  };
+  }, [closeCompanionWindow, id]);
+
+  const annotationRef = useRef(annotation);
+  annotationRef.current = annotation;
+
+  useEffect(() => {
+    /** Action when all annotation shapes have been deleted */
+    const handleAnnotationEmpty = () => {
+      const anno = annotationRef.current;
+
+      if (anno?.id) {
+        // Existing annotation: delete from storage
+        canvases.forEach((canvas) => {
+          const storageAdapter = config.annotation.adapter(canvas.id);
+          storageAdapter.delete(anno.id).then((annoPage) => {
+            receiveAnnotation(canvas.id, storageAdapter.annotationPageId, annoPage);
+          });
+        });
+      }
+
+      closeFormCompanionWindow();
+    };
+
+    // Listen for MAE_ANNOTATION_EMPTY_EVENT
+    document.addEventListener(MAE_ANNOTATION_EMPTY_EVENT, handleAnnotationEmpty);
+    return () => document.removeEventListener(MAE_ANNOTATION_EMPTY_EVENT, handleAnnotationEmpty);
+  }, [canvases, config, receiveAnnotation, closeFormCompanionWindow]);
 
   /**
    * Save the annotation

--- a/src/annotationForm/AnnotationForm.jsx
+++ b/src/annotationForm/AnnotationForm.jsx
@@ -15,7 +15,6 @@ import AnnotationFormHeader from './AnnotationFormHeader';
 import AnnotationFormBody from './AnnotationFormBody';
 import '../custom.css';
 import UnsupportedMedia from './UnsupportedMedia';
-import { MAE_ANNOTATION_EMPTY_EVENT } from '../hotkeys/hotkeysEvents';
 
 /**
  * Component for submitting a form to create or edit an annotation.
@@ -66,7 +65,7 @@ function AnnotationForm(
         setTemplateType(getTemplateType(t, TEMPLATE.IIIF_TYPE));
       }
     } else {
-      // New: use defaultForm if configured, otherwise show selector
+      // Use defaultForm if configured, otherwise show selector
       const { defaultForm } = getContextParams(config);
       if (defaultForm && DEFAULT_FORM_MAP[defaultForm]) {
         setTemplateType(getTemplateType(t, DEFAULT_FORM_MAP[defaultForm]));
@@ -124,28 +123,28 @@ function AnnotationForm(
   const annotationRef = useRef(annotation);
   annotationRef.current = annotation;
 
-  useEffect(() => {
-    /** Action when all annotation shapes have been deleted */
-    const handleAnnotationEmpty = () => {
-      const anno = annotationRef.current;
-
-      if (anno?.id) {
-        // Existing annotation: delete from storage
-        canvases.forEach((canvas) => {
-          const storageAdapter = config.annotation.adapter(canvas.id);
-          storageAdapter.delete(anno.id).then((annoPage) => {
-            receiveAnnotation(canvas.id, storageAdapter.annotationPageId, annoPage);
-          });
-        });
-      }
-
-      closeFormCompanionWindow();
-    };
-
-    // Listen for MAE_ANNOTATION_EMPTY_EVENT
-    document.addEventListener(MAE_ANNOTATION_EMPTY_EVENT, handleAnnotationEmpty);
-    return () => document.removeEventListener(MAE_ANNOTATION_EMPTY_EVENT, handleAnnotationEmpty);
-  }, [canvases, config, receiveAnnotation, closeFormCompanionWindow]);
+  // useEffect(() => {
+  //   /** Action when all annotation shapes have been deleted */
+  //   const handleAnnotationEmpty = () => {
+  //     const anno = annotationRef.current;
+  //
+  //     if (anno?.id) {
+  //       // Existing annotation: delete from storage
+  //       canvases.forEach((canvas) => {
+  //         const storageAdapter = config.annotation.adapter(canvas.id);
+  //         storageAdapter.delete(anno.id).then((annoPage) => {
+  //           receiveAnnotation(canvas.id, storageAdapter.annotationPageId, annoPage);
+  //         });
+  //       });
+  //     }
+  //
+  //     closeFormCompanionWindow();
+  //   };
+  //
+  //   // Listen for MAE_ANNOTATION_EMPTY_EVENT
+  //   document.addEventListener(MAE_ANNOTATION_EMPTY_EVENT, handleAnnotationEmpty);
+  //   return () => document.removeEventListener(MAE_ANNOTATION_EMPTY_EVENT, handleAnnotationEmpty);
+  // }, [canvases, config, receiveAnnotation, closeFormCompanionWindow]);
 
   /**
    * Save the annotation

--- a/src/annotationForm/AnnotationForm.jsx
+++ b/src/annotationForm/AnnotationForm.jsx
@@ -3,9 +3,12 @@ import { ConnectedCompanionWindow } from 'mirador';
 import PropTypes from 'prop-types';
 import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { isEmptyValue, convertAnnotationStateToBeSaved } from '../IIIFUtils';
+import { convertAnnotationStateToBeSaved } from '../IIIFUtils';
 import AnnotationFormTemplateSelector from './AnnotationFormTemplateSelector';
-import { getTemplateType, saveAnnotationInStorageAdapter, TEMPLATE } from './AnnotationFormUtils';
+import {
+  getTemplateType, saveAnnotationInStorageAdapter, TEMPLATE, DEFAULT_FORM_MAP,
+} from './AnnotationFormUtils';
+import { getContextParams } from '../contextParams';
 import AnnotationFormHeader from './AnnotationFormHeader';
 import AnnotationFormBody from './AnnotationFormBody';
 import '../custom.css';
@@ -58,6 +61,12 @@ function AnnotationForm(
       } else {
         // Annotation has been created with other IIIF annotation editor
         setTemplateType(getTemplateType(t, TEMPLATE.IIIF_TYPE));
+      }
+    } else {
+      // New: use defaultForm if configured, otherwise show selector
+      const { defaultForm } = getContextParams(config);
+      if (defaultForm && DEFAULT_FORM_MAP[defaultForm]) {
+        setTemplateType(getTemplateType(t, DEFAULT_FORM_MAP[defaultForm]));
       }
     }
   }

--- a/src/annotationForm/AnnotationFormFooter.jsx
+++ b/src/annotationForm/AnnotationFormFooter.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 import WhoAndWhenFormSection, { SECTION_MODE } from './WhoAndWhenFormSection';
 import { MAE_SAVE_EVENT } from '../hotkeys/hotkeysEvents';
+import HotkeyTooltip from '../hotkeys/HotkeyTooltip';
 
 /** Annotation form footer, save or cancel the edition/creation of an annotation */
 function AnnotationFormFooter({
@@ -42,7 +43,7 @@ function AnnotationFormFooter({
       }
       <Divider sx={{ m: 1 }} />
       <Grid sx={{ mt: 1 }} container spacing={1} justifyContent="flex-end">
-        <Tooltip title={t('cancel')}>
+        <Tooltip title={<HotkeyTooltip label={t('cancel')} action="escape" />}>
           <Button
             sx={{ m: 1 }}
             onClick={closeFormCompanionWindow}
@@ -50,7 +51,7 @@ function AnnotationFormFooter({
             {t('cancel')}
           </Button>
         </Tooltip>
-        <Tooltip title={t('save')}>
+        <Tooltip title={<HotkeyTooltip label={t('save')} action="save" />}>
           <Button
             sx={{ m: 1 }}
             variant="contained"

--- a/src/annotationForm/AnnotationFormFooter.jsx
+++ b/src/annotationForm/AnnotationFormFooter.jsx
@@ -2,8 +2,9 @@ import {
   Button, Divider, Grid, Tooltip,
 } from '@mui/material';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import WhoAndWhenFormSection, { SECTION_MODE } from './WhoAndWhenFormSection';
+import { MAE_SAVE_EVENT } from '../hotkeys/hotkeysEvents';
 
 /** Annotation form footer, save or cancel the edition/creation of an annotation */
 function AnnotationFormFooter({
@@ -12,9 +13,16 @@ function AnnotationFormFooter({
   saveAnnotation,
   t,
 }) {
-  /**
-   * Validate form and save annotation
-   */
+  // Ref to not re-register on every render
+  const saveRef = useRef(saveAnnotation);
+  saveRef.current = saveAnnotation;
+
+  useEffect(() => {
+    /** When MAE_SAVE_EVENT triggers, validate form and save annotation */
+    const handleSave = () => saveRef.current();
+    document.addEventListener(MAE_SAVE_EVENT, handleSave);
+    return () => document.removeEventListener(MAE_SAVE_EVENT, handleSave);
+  }, []);
 
   return (
     <>

--- a/src/annotationForm/AnnotationFormHeader.jsx
+++ b/src/annotationForm/AnnotationFormHeader.jsx
@@ -33,7 +33,7 @@ export default function AnnotationFormHeader(
       <Grid>
         {annotation.id == null
           && (
-            <MiradorMenuButton aria-label="back" TooltipProps="back">
+            <MiradorMenuButton aria-label="back" TooltipProps={{ title: 'back' }}>
               <ChevronLeftIcon onClick={goBackToTemplateSelection} />
             </MiradorMenuButton>
           )}

--- a/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.jsx
+++ b/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.jsx
@@ -135,7 +135,7 @@ export default function AnnotationDrawing(
         updateCurrentShapeInShapes(newCurrentShape);
       }
     }
-  }, [drawingState.shapes.length]);
+  }, [drawingState]);
 
   useEffect(() => {
     // Perform an action when fillColor, strokeColor, or strokeWidth change

--- a/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.jsx
+++ b/src/annotationForm/AnnotationFormOverlay/AnnotationDrawing.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { Stage } from 'react-konva';
 import { v4 as uuidv4 } from 'uuid';
 import ParentComponent from './KonvaDrawing/shapes/ParentComponent';
-import { OVERLAY_TOOL, SHAPES_TOOL } from './KonvaDrawing/KonvaUtils';
+import { KONVA_MODE, OVERLAY_TOOL, SHAPES_TOOL } from './KonvaDrawing/KonvaUtils';
 
 /** All the stuff to draw on the canvas */
 export default function AnnotationDrawing(
@@ -25,16 +25,27 @@ export default function AnnotationDrawing(
     windowId,
   },
 ) {
-  const width = playerReferences.getMediaTrueWidth();
+  // const width = playerReferences.getMediaTrueWidth();
 
   const [isDrawing, setIsDrawing] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
 
-  // This useEffect is necessary to update the scale when the window is resized. If not drawing
-  // stage is not aligned with the image.
   useEffect(() => {
-    updateScale(playerReferences.getZoom());
-  }, [{ width }]);
+    const viewer = playerReferences.media?.current;
+    if (viewer && typeof viewer.addHandler === 'function') {
+      /** Update scale on viewer animation and resize events */
+      const onViewportChange = () => updateScale();
+      viewer.addHandler('animation', onViewportChange);
+      viewer.addHandler('resize', onViewportChange);
+      updateScale();
+      return () => {
+        viewer.removeHandler('animation', onViewportChange);
+        viewer.removeHandler('resize', onViewportChange);
+      };
+    }
+    updateScale();
+    return undefined;
+  }, [playerReferences, updateScale]);
 
   useEffect(() => {
     if (toolState.imageEvent?.id && !drawingState.currentShape) {
@@ -57,74 +68,6 @@ export default function AnnotationDrawing(
     }
     setIsDrawing(false);
   }, [toolState]);
-
-  useEffect(() => {
-    if (!isDrawing) {
-      const newCurrentShape = drawingState[drawingState.shapes.length - 1];
-      // get the latest shape in the list
-      if (newCurrentShape) {
-        updateCurrentShapeInShapes(newCurrentShape);
-      }
-    }
-  }, [drawingState]);
-
-  useEffect(() => {
-    // Perform an action when fillColor, strokeColor, or strokeWidth change
-    // update current shape
-    if (drawingState.currentShape) {
-      // eslint-disable-next-line no-param-reassign
-      drawingState.currentShape.fill = toolState.fillColor;
-      // eslint-disable-next-line no-param-reassign
-      drawingState.currentShape.stroke = toolState.strokeColor;
-      // eslint-disable-next-line no-param-reassign
-      drawingState.currentShape.strokeWidth = toolState.strokeWidth;
-      // eslint-disable-next-line no-param-reassign
-      drawingState.currentShape.text = toolState.text;
-      updateCurrentShapeInShapes(drawingState.currentShape);
-    }
-  }, [toolState]);
-
-  // eslint-disable-next-line consistent-return
-  useLayoutEffect(() => {
-    if (drawingState.shapes.find((s) => s.id === drawingState.currentShape?.id)) {
-      window.addEventListener('keydown', handleKeyPress);
-
-      // Set here all the properties of the current shape for the tool options
-      setColorToolFromCurrentShape(
-        {
-          fillColor: drawingState.currentShape.fill,
-          strokeColor: drawingState.currentShape.stroke,
-          strokeWidth: drawingState.currentShape.strokeWidth,
-          text: drawingState.currentShape.text,
-        },
-      );
-
-      return () => {
-        window.removeEventListener('keydown', handleKeyPress);
-      };
-    }
-  }, [drawingState.currentShape]);
-
-  // eslint-disable-next-line consistent-return
-  useLayoutEffect(() => {
-    if (drawingState.shapes.find((s) => s.id === drawingState.currentShape?.id)) {
-      window.addEventListener('keydown', handleKeyPress);
-
-      // Set here all the properties of the current shape for the tool options
-      setColorToolFromCurrentShape(
-        {
-          fillColor: drawingState.currentShape.fill,
-          strokeColor: drawingState.currentShape.stroke,
-          strokeWidth: drawingState.currentShape.strokeWidth,
-          text: drawingState.currentShape.text,
-        },
-      );
-
-      return () => {
-        window.removeEventListener('keydown', handleKeyPress);
-      };
-    }
-  }, [drawingState.currentShape]);
 
   /** */
   const handleKeyPress = (e) => {
@@ -176,12 +119,60 @@ export default function AnnotationDrawing(
       setDrawingState((prevState) => ({
         ...prevState,
         currentShape: newCurrentShape,
-        shapes: prevState.shapes.map((shape) => (shape.id === newCurrentShape.id
-          ? { ...shape, ...newCurrentShape }
-          : shape)),
+        shapes: prevState.shapes.map((shape) => (
+          shape.id === newCurrentShape.id
+            ? { ...shape, ...newCurrentShape }
+            : shape)),
       }));
     }
   };
+
+  useEffect(() => {
+    if (!isDrawing) {
+      const newCurrentShape = drawingState[drawingState.shapes.length - 1];
+      // get the latest shape in the list
+      if (newCurrentShape) {
+        updateCurrentShapeInShapes(newCurrentShape);
+      }
+    }
+  }, [drawingState.shapes.length]);
+
+  useEffect(() => {
+    // Perform an action when fillColor, strokeColor, or strokeWidth change
+    // update current shape
+    if (drawingState.currentShape && displayMode !== KONVA_MODE.TARGET) {
+      // eslint-disable-next-line no-param-reassign
+      drawingState.currentShape.fill = toolState.fillColor;
+      // eslint-disable-next-line no-param-reassign
+      drawingState.currentShape.stroke = toolState.strokeColor;
+      // eslint-disable-next-line no-param-reassign
+      drawingState.currentShape.strokeWidth = toolState.strokeWidth;
+      // eslint-disable-next-line no-param-reassign
+      drawingState.currentShape.text = toolState.text;
+      updateCurrentShapeInShapes(drawingState.currentShape);
+    }
+  }, [toolState]);
+
+  // eslint-disable-next-line consistent-return
+  useLayoutEffect(() => {
+    if (drawingState.shapes.find((s) => s.id === drawingState.currentShape?.id)) {
+      window.addEventListener('keydown', handleKeyPress);
+
+      // Set here all the properties of the current shape for the tool options
+      setColorToolFromCurrentShape(
+        {
+          fillColor: drawingState.currentShape.fill,
+          strokeColor: drawingState.currentShape.stroke,
+          strokeWidth: drawingState.currentShape.strokeWidth,
+          text: drawingState.currentShape.text,
+        },
+      );
+
+      return () => {
+        window.removeEventListener('keydown', handleKeyPress);
+      };
+    }
+  }, [drawingState.currentShape]);
 
   /** */
   const onShapeClick = async (shp) => {
@@ -224,10 +215,7 @@ export default function AnnotationDrawing(
    * @param {Object} evt - The event object containing the target shape's modified attributes.
    */
   const onTransform = (evt) => {
-
     console.log('onTransform');
-
-
 
     const modifiedShape = evt.target.attrs;
 
@@ -240,7 +228,7 @@ export default function AnnotationDrawing(
     }
     updateCurrentShapeInShapes(shape);
 
-    if(!isResizing){
+    if (!isResizing) {
       setIsResizing(true);
     }
   };

--- a/src/annotationForm/AnnotationFormOverlay/AnnotationFormOverlay.jsx
+++ b/src/annotationForm/AnnotationFormOverlay/AnnotationFormOverlay.jsx
@@ -16,6 +16,7 @@ import {
   TARGET_VIEW,
 } from '../AnnotationFormUtils';
 import { isShapesTool, KONVA_MODE, OVERLAY_TOOL } from './KonvaDrawing/KonvaUtils';
+import HotkeyTooltip from "../../hotkeys/HotkeyTooltip";
 
 // eslint-disable-next-line no-empty-pattern
 const OverlayIconAndTitleContainer = styled(Grid)(({  }) => ({
@@ -158,7 +159,7 @@ function AnnotationFormOverlay({
               <CursorIcon />
             </ToggleButton>
           </Tooltip>
-          <Tooltip title={t('delete')}>
+          <Tooltip title={<HotkeyTooltip label={t('delete')} action="delete" />}>
             <ToggleButton
               value={OVERLAY_TOOL.DELETE}
               aria-label={t('select_cursor')}

--- a/src/annotationForm/AnnotationFormOverlay/AnnotationFormOverlay.jsx
+++ b/src/annotationForm/AnnotationFormOverlay/AnnotationFormOverlay.jsx
@@ -88,6 +88,10 @@ function AnnotationFormOverlay({
         updateCurrentShapeInShapes(null);
       } else {
         setToolState((s) => (s.activeTool === tool ? s : { ...s, activeTool: tool }));
+        // Deselect shape when switching to drawing tool
+        if (tool !== OVERLAY_TOOL.EDIT) {
+          updateCurrentShapeInShapes(null);
+        }
       }
     },
     [displayMode, setToolState, updateCurrentShapeInShapes],

--- a/src/annotationForm/AnnotationFormOverlay/ShapesList.jsx
+++ b/src/annotationForm/AnnotationFormOverlay/ShapesList.jsx
@@ -8,6 +8,7 @@ import DeleteIcon from '@mui/icons-material/DeleteForever';
 import { styled } from '@mui/material/styles';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
+import HotkeyTooltip from "../../hotkeys/HotkeyTooltip";
 
 /**
  * Accordion presentation of shapes
@@ -55,7 +56,7 @@ function ShapesList({
               >
                 {t(shape.type)}
               </Typography>
-              <Tooltip title={t('delete')}>
+              <Tooltip title={<HotkeyTooltip label={t('delete')} action="delete" />}>
                 <IconButton onClick={() => deleteShape(shape.id)} edge="end" aria-label="delete">
                   <DeleteIcon />
                 </IconButton>

--- a/src/annotationForm/AnnotationFormUtils.jsx
+++ b/src/annotationForm/AnnotationFormUtils.jsx
@@ -14,6 +14,13 @@ export const TEMPLATE = {
   TEXT_TYPE: 'text',
 };
 
+/** Maps defaultForm context param values to TEMPLATE */
+export const DEFAULT_FORM_MAP = {
+  expert: TEMPLATE.IIIF_TYPE,
+  note: TEMPLATE.MULTIPLE_BODY_TYPE,
+  tag: TEMPLATE.TAGGING_TYPE,
+};
+
 // TODO Move in MediaUtils
 export const MEDIA_TYPES = {
   AUDIO: 'Audio',

--- a/src/annotationForm/MultipleBodyTemplate.jsx
+++ b/src/annotationForm/MultipleBodyTemplate.jsx
@@ -8,6 +8,7 @@ import { TEMPLATE } from './AnnotationFormUtils';
 import TargetFormSection from './TargetFormSection';
 import { resizeKonvaStage } from './AnnotationFormOverlay/KonvaDrawing/KonvaUtils';
 import { MultiTagsInput } from './MultiTagsInput';
+import { getContextParams } from '../contextParams';
 import { TextCommentInput } from './TextCommentInput';
 
 /** Tagging Template* */
@@ -21,17 +22,21 @@ export default function MultipleBodyTemplate(
     windowId,
   },
 ) {
-  const annotationConfig = useSelector((state) => getConfig(state)).annotation;
+  const config = useSelector((state) => getConfig(state));
+  const annotationConfig = config.annotation;
   const tagsSuggestions = annotationConfig.tagsSuggestions ?? [];
 
   let maeAnnotation = annotation;
 
   if (!maeAnnotation.id) {
+    const { defaultTags } = getContextParams(config);
+    const initialTags = defaultTags.map((tag) => ({ label: tag, value: tag }));
+
     // If the annotation does not have maeData, the annotation was not created with mae
     maeAnnotation = {
       body: [],
       maeData: {
-        tags: [],
+        tags: initialTags,
         target: null,
         templateType: TEMPLATE.MULTIPLE_BODY_TYPE,
         textBody: {

--- a/src/annotationForm/TaggingTemplate.jsx
+++ b/src/annotationForm/TaggingTemplate.jsx
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { Grid, TextField } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { getConfig } from 'mirador';
 import AnnotationFormFooter from './AnnotationFormFooter';
 import { TEMPLATE } from './AnnotationFormUtils';
 import TargetFormSection from './TargetFormSection';
 import { resizeKonvaStage } from './AnnotationFormOverlay/KonvaDrawing/KonvaUtils';
+import { getContextParams } from '../contextParams';
 
 /** Tagging Template* */
 export default function TaggingTemplate(
@@ -18,14 +21,18 @@ export default function TaggingTemplate(
     windowId,
   },
 ) {
+  const config = useSelector((state) => getConfig(state));
   let maeAnnotation = annotation;
 
   if (!maeAnnotation.id) {
+    const { defaultTags } = getContextParams(config);
+    const initialValue = defaultTags.length > 0 ? defaultTags[0] : '';
+
     // If the annotation does not have maeData, the annotation was not created with mae
     maeAnnotation = {
       body: {
         type: 'Image',
-        value: '',
+        value: initialValue,
       },
       maeData: {
         target: null,

--- a/src/annotationForm/TargetSpatialInput.jsx
+++ b/src/annotationForm/TargetSpatialInput.jsx
@@ -5,8 +5,11 @@ import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
 import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { getConfig } from 'mirador';
 import AnnotationDrawing from './AnnotationFormOverlay/AnnotationDrawing';
 import { TARGET_TOOL_STATE, TARGET_VIEW } from './AnnotationFormUtils';
+import { getContextParams } from '../contextParams';
 import AnnotationFormOverlay from './AnnotationFormOverlay/AnnotationFormOverlay';
 import { KONVA_MODE, OVERLAY_TOOL } from './AnnotationFormOverlay/KonvaDrawing/KonvaUtils';
 
@@ -24,13 +27,20 @@ export function TargetSpatialInput({
   windowId,
 }) {
   const { t } = useTranslation();
+  const config = useSelector((state) => getConfig(state));
+  const { editMode: isEditMode } = getContextParams(config);
 
-  const [drawingState, setDrawingState] = useState(() => ({
-    currentShape: null,
-    isDrawing: false,
-    shapes: Array.isArray(targetDrawingState?.shapes) ? targetDrawingState.shapes : [],
-    ...targetDrawingState,
-  }));
+  const [drawingState, setDrawingState] = useState(() => {
+    const shapes = Array.isArray(targetDrawingState?.shapes) ? targetDrawingState.shapes : [];
+    return {
+      currentShape: null,
+      isDrawing: false,
+      shapes,
+      ...targetDrawingState,
+      // In editMode, auto-select the first shape for immediate resize
+      ...(isEditMode && shapes.length > 0 ? { currentShape: shapes[0] } : {}),
+    };
+  });
 
   const hasExistingShapes = Array.isArray(targetDrawingState?.shapes)
     && targetDrawingState.shapes.length > 0;

--- a/src/annotationForm/TargetSpatialInput.jsx
+++ b/src/annotationForm/TargetSpatialInput.jsx
@@ -12,7 +12,7 @@ import { TARGET_TOOL_STATE, TARGET_VIEW } from './AnnotationFormUtils';
 import { getContextParams } from '../contextParams';
 import AnnotationFormOverlay from './AnnotationFormOverlay/AnnotationFormOverlay';
 import { KONVA_MODE, OVERLAY_TOOL } from './AnnotationFormOverlay/KonvaDrawing/KonvaUtils';
-import { MAE_DELETE_SHAPE_EVENT, MAE_ANNOTATION_EMPTY_EVENT } from '../hotkeys/hotkeysEvents';
+import { MAE_DELETE_SHAPE_EVENT } from '../hotkeys/hotkeysEvents';
 
 /**
  * TargetSpatialInput - Target spatial input component
@@ -93,13 +93,13 @@ export function TargetSpatialInput({
         const remaining = shapes.filter((s) => s.id !== currentShape.id);
         setDrawingState((prev) => ({ ...prev, currentShape: null, shapes: remaining }));
 
-        if (remaining.length === 0) {
-          // No shapes left: notify AnnotationForm to clean up
-          document.dispatchEvent(new CustomEvent(MAE_ANNOTATION_EMPTY_EVENT));
-        }
+        // if (remaining.length === 0) {
+        //   // No shapes left: notify AnnotationForm to clean up
+        //   document.dispatchEvent(new CustomEvent(MAE_ANNOTATION_EMPTY_EVENT));
+        // }
       } else {
-        // No shapes at all: just signal empty
-        document.dispatchEvent(new CustomEvent(MAE_ANNOTATION_EMPTY_EVENT));
+        // // No shapes at all: just signal empty
+        // document.dispatchEvent(new CustomEvent(MAE_ANNOTATION_EMPTY_EVENT));
       }
     };
 

--- a/src/annotationForm/TargetSpatialInput.jsx
+++ b/src/annotationForm/TargetSpatialInput.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useLayoutEffect, useRef, useState, useCallback,
+  useEffect, useLayoutEffect, useRef, useState, useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@mui/material/Typography';
@@ -12,6 +12,7 @@ import { TARGET_TOOL_STATE, TARGET_VIEW } from './AnnotationFormUtils';
 import { getContextParams } from '../contextParams';
 import AnnotationFormOverlay from './AnnotationFormOverlay/AnnotationFormOverlay';
 import { KONVA_MODE, OVERLAY_TOOL } from './AnnotationFormOverlay/KonvaDrawing/KonvaUtils';
+import { MAE_DELETE_SHAPE_EVENT, MAE_ANNOTATION_EMPTY_EVENT } from '../hotkeys/hotkeysEvents';
 
 /**
  * TargetSpatialInput - Target spatial input component
@@ -77,6 +78,34 @@ export function TargetSpatialInput({
       if (filtered.length === prev.shapes.length) return prev;
       return { ...prev, currentShape: null, shapes: filtered };
     });
+  }, []);
+
+  const drawingStateRef = useRef(drawingState);
+  drawingStateRef.current = drawingState;
+
+  useEffect(() => {
+    /** Action to delete shape when selected */
+    const handleDeleteShape = () => {
+      const { currentShape, shapes } = drawingStateRef.current;
+
+      if (currentShape) {
+        // Delete the selected shape
+        const remaining = shapes.filter((s) => s.id !== currentShape.id);
+        setDrawingState((prev) => ({ ...prev, currentShape: null, shapes: remaining }));
+
+        if (remaining.length === 0) {
+          // No shapes left: notify AnnotationForm to clean up
+          document.dispatchEvent(new CustomEvent(MAE_ANNOTATION_EMPTY_EVENT));
+        }
+      } else {
+        // No shapes at all: just signal empty
+        document.dispatchEvent(new CustomEvent(MAE_ANNOTATION_EMPTY_EVENT));
+      }
+    };
+
+    // Listen for MAE_DELETE_SHAPE_EVENT triggered by hotkey
+    document.addEventListener(MAE_DELETE_SHAPE_EVENT, handleDeleteShape);
+    return () => document.removeEventListener(MAE_DELETE_SHAPE_EVENT, handleDeleteShape);
   }, []);
 
   // Synchronize currentShape with both drawingState.currentShape and

--- a/src/contextParams.js
+++ b/src/contextParams.js
@@ -1,0 +1,79 @@
+/**
+ * Utility file to set config via URL search params
+ * or Mirador config (under `annotation`).
+ * URL params take precedence over config values.
+ *
+ * Types:
+ *   - boolean:  "true" / "false"
+ *   - string:   any string value
+ *   - number:   numeric value
+ *   - array:    comma-separated strings
+ */
+import { useMemo } from 'react';
+
+// Available parameters: extend this object to add new context parameters
+const PARAM_DEFINITIONS = {
+  editMode: { default: false, type: 'boolean' },
+};
+
+const parsers = {
+  array: (value) => (value ? value.split(',').map((s) => s.trim()).filter(Boolean) : []),
+  boolean: (value) => value === 'true',
+  number: (value) => { const n = Number(value); return Number.isNaN(n) ? null : n; },
+  string: (value) => value || null,
+};
+
+let urlParams = null;
+
+/**
+ * URL param parsed on page load
+ * @returns {object} { paramName: paramValue }
+ */
+function getUrlParams() {
+  if (!urlParams) {
+    const searchParams = new URLSearchParams(window.location.search);
+    urlParams = {};
+    Object.entries(PARAM_DEFINITIONS).forEach(([key, def]) => {
+      const raw = searchParams.get(key);
+      if (raw !== null) {
+        urlParams[key] = parsers[def.type](raw);
+      }
+    });
+  }
+  return urlParams;
+}
+
+/**
+ * Resolve context parameters by merging (in priority order):
+ *   1. URL search params
+ *   2. config.annotation (from Mirador config)
+ *   3. PARAM_DEFINITIONS defaults
+ *
+ * @param {object} config - Mirador config object (or subset containing `annotation`).
+ * @returns {object} Resolved parameters keyed by name.
+ */
+export function getContextParams(config) {
+  const url = getUrlParams();
+  const result = {};
+
+  Object.entries(PARAM_DEFINITIONS).forEach(([key, def]) => {
+    if (key in url) {
+      result[key] = url[key];
+    } else if (config?.annotation?.[key] !== undefined) {
+      result[key] = config.annotation[key];
+    } else {
+      result[key] = def.default;
+    }
+  });
+
+  return result;
+}
+
+/**
+ * React hook
+ * @param {object} config - Mirador config object.
+ * @returns {object} Resolved parameters (stable reference while config is unchanged).
+ */
+export function useContextParams(config) {
+  return useMemo(() => getContextParams(config), [config]);
+}

--- a/src/contextParams.js
+++ b/src/contextParams.js
@@ -13,6 +13,8 @@ import { useMemo } from 'react';
 
 // Available parameters: extend this object to add new context parameters
 const PARAM_DEFINITIONS = {
+  defaultForm: { default: null, type: 'string' },
+  defaultTags: { default: [], type: 'array' },
   editMode: { default: false, type: 'boolean' },
 };
 

--- a/src/hotkeys/HotkeyTooltip.jsx
+++ b/src/hotkeys/HotkeyTooltip.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Typography } from '@mui/material';
+import HOTKEY_ACTIONS from './hotkeysDefinitions';
+
+const hkSx = {
+  bgcolor: 'rgba(255,255,255,0.15)',
+  border: '1px solid rgba(255,255,255,0.3)',
+  borderRadius: '4px',
+  fontSize: '0.75em',
+  ml: 1,
+  my: 1,
+  px: 0.5,
+  py: -0.25,
+};
+
+/** Find hotkey entry by its handler function reference */
+function getHotkeyKeys(action) {
+  return (
+    Object.prototype.hasOwnProperty.call(HOTKEY_ACTIONS, action)
+      ? HOTKEY_ACTIONS[action].keys
+      : null
+  );
+}
+
+/**
+ * Tooltip content: label + styled hotkey tags
+ * @param label
+ * @param action
+ * @returns {React.JSX.Element}
+ * @constructor
+ */
+export default function HotkeyTooltip({ label, action }) {
+  const keys = getHotkeyKeys(action);
+  if (!keys) return label;
+  return (
+    <Typography variant="body2" component="span" sx={{ alignItems: 'center', display: 'inline-flex' }}>
+      {label}
+      {keys.map((k) => (
+        <Typography key={k} component="HotKey" variant="caption" sx={hkSx}>
+          {k}
+        </Typography>
+      ))}
+    </Typography>
+  );
+}
+
+HotkeyTooltip.propTypes = {
+  action: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+};

--- a/src/hotkeys/HotkeysListener.jsx
+++ b/src/hotkeys/HotkeysListener.jsx
@@ -8,18 +8,21 @@ const IGNORED_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 /** Check if target is editable */
 const isEditableTarget = (el) => IGNORED_TAGS.has(el?.tagName) || el?.isContentEditable;
 
+// Track the active handler so we can always clean up correctly,
+// even if React unmounts/remounts due to error boundaries.
 let activeHandler = null;
 
 /**
- * Registers a global keydown listener
+ * Registers a global keydown listener.
  * Uses the Redux store directly so the listener reads current state
- * without React re-renders
+ * without React re-renders.
  */
 export default function HotkeysListener() {
   const store = useStore();
 
   useEffect(() => {
     // Remove any stale listener left from a previous mount
+    // (e.g. after an error boundary re-creation)
     if (activeHandler) {
       document.removeEventListener('keydown', activeHandler);
       activeHandler = null;

--- a/src/hotkeys/HotkeysListener.jsx
+++ b/src/hotkeys/HotkeysListener.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useStore } from 'react-redux';
 import { getFocusedWindowId, getConfig } from 'mirador';
-import HOTKEYS from './hotkeysDefinitions';
+import HOTKEY_ACTIONS from './hotkeysDefinitions';
 
 /** Elements where keystrokes should NOT trigger hotkeys */
 const IGNORED_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
@@ -31,7 +31,7 @@ export default function HotkeysListener() {
     /** Handler for keydown events */
     const handler = (e) => {
       if (isEditableTarget(e.target)) return;
-      const match = HOTKEYS.find((h) => h.keys.includes(e.key));
+      const match = Object.values(HOTKEY_ACTIONS).find((h) => h.keys.includes(e.key));
       if (!match) return;
 
       const state = store.getState();

--- a/src/hotkeys/HotkeysListener.jsx
+++ b/src/hotkeys/HotkeysListener.jsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+import { useStore } from 'react-redux';
+import { getFocusedWindowId, getConfig } from 'mirador';
+import HOTKEYS from './hotkeysDefinitions';
+
+/** Elements where keystrokes should NOT trigger hotkeys */
+const IGNORED_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+/** Check if target is editable */
+const isEditableTarget = (el) => IGNORED_TAGS.has(el?.tagName) || el?.isContentEditable;
+
+let listenerActive = false;
+
+/**
+ * Registers a global keydown listener
+ * Uses the Redux store directly so the listener reads current state
+ * without React re-renders
+ */
+export default function HotkeysListener() {
+  const store = useStore();
+
+  useEffect(() => {
+    if (listenerActive) {
+      return undefined;
+    }
+    listenerActive = true;
+
+    /** Handler for keydown events */
+    const handler = (e) => {
+      // console.log(e.key);
+
+      if (isEditableTarget(e.target)) return;
+      const match = HOTKEYS.find((h) => h.keys.includes(e.key));
+      if (!match) return;
+
+      const state = store.getState();
+      const windowId = getFocusedWindowId(state);
+      if (!windowId) return;
+
+      const config = getConfig(state);
+      if (config?.annotation?.readonly) return;
+
+      e.preventDefault();
+      match.handler({
+        config,
+        dispatch: store.dispatch,
+        state,
+        windowId,
+      });
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+      listenerActive = false;
+    };
+  }, [store]);
+
+  return null;
+}

--- a/src/hotkeys/HotkeysListener.jsx
+++ b/src/hotkeys/HotkeysListener.jsx
@@ -8,7 +8,7 @@ const IGNORED_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 /** Check if target is editable */
 const isEditableTarget = (el) => IGNORED_TAGS.has(el?.tagName) || el?.isContentEditable;
 
-let listenerActive = false;
+let activeHandler = null;
 
 /**
  * Registers a global keydown listener
@@ -19,15 +19,14 @@ export default function HotkeysListener() {
   const store = useStore();
 
   useEffect(() => {
-    if (listenerActive) {
-      return undefined;
+    // Remove any stale listener left from a previous mount
+    if (activeHandler) {
+      document.removeEventListener('keydown', activeHandler);
+      activeHandler = null;
     }
-    listenerActive = true;
 
     /** Handler for keydown events */
     const handler = (e) => {
-      // console.log(e.key);
-
       if (isEditableTarget(e.target)) return;
       const match = HOTKEYS.find((h) => h.keys.includes(e.key));
       if (!match) return;
@@ -48,10 +47,13 @@ export default function HotkeysListener() {
       });
     };
 
+    activeHandler = handler;
     document.addEventListener('keydown', handler);
     return () => {
       document.removeEventListener('keydown', handler);
-      listenerActive = false;
+      if (activeHandler === handler) {
+        activeHandler = null;
+      }
     };
   }, [store]);
 

--- a/src/hotkeys/hotkeysDefinitions.js
+++ b/src/hotkeys/hotkeysDefinitions.js
@@ -6,11 +6,39 @@ import {
   receiveAnnotation,
   removeCompanionWindow,
 } from 'mirador';
+import { MAE_DELETE_SHAPE_EVENT, MAE_SAVE_EVENT } from './hotkeysEvents';
 
-/** Delete selected annotation on Delete/Backspace */
-function deleteSelectedAnnotation({
+/** Return the open companion windows for a given window */
+function getAnnotationCompanionWindows(state, windowId) {
+  const cws = getCompanionWindowsForContent(state, {
+    content: 'annotationCreation',
+    windowId,
+  });
+  return Object.values(cws).filter((cw) => cw?.id);
+}
+
+/** Close every open companion window for a given window */
+function closeAnnotationCompanionWindows(state, dispatch, windowId) {
+  getAnnotationCompanionWindows(state, windowId).forEach((cw) => {
+    dispatch(removeCompanionWindow(windowId, cw.id));
+  });
+}
+
+/** Delete the currently selected shape */
+function deleteSelectedShape({
   state, dispatch, windowId, config,
 }) {
+  const companionWindows = getAnnotationCompanionWindows(state, windowId);
+
+  if (companionWindows.length > 0) {
+    // dispatch MAE_DELETE_SHAPE_EVENT so TargetSpatialInput can handle shape removal
+    // If last shape is removed, TargetSpatialInput will dispatch MAE_ANNOTATION_EMPTY_EVENT
+    // and AnnotationForm will be empty
+    document.dispatchEvent(new CustomEvent(MAE_DELETE_SHAPE_EVENT));
+    return;
+  }
+
+  // No companion window, delete the whole annotation
   const annotationId = getSelectedAnnotationId(state, { windowId });
   if (!annotationId) return;
 
@@ -18,7 +46,6 @@ function deleteSelectedAnnotation({
   if (!storageAdapter) return;
 
   const canvases = getVisibleCanvases(state, { windowId });
-
   canvases.forEach((canvas) => {
     const adapter = storageAdapter(canvas.id);
     adapter.delete(annotationId).then((annoPage) => {
@@ -26,27 +53,35 @@ function deleteSelectedAnnotation({
     });
   });
 
-  // Close companion window
-  const companionWindows = getCompanionWindowsForContent(state, {
-    content: 'annotationCreation',
-    windowId,
-  });
-  Object.values(companionWindows).forEach((cw) => {
-    if (cw?.id) {
-      dispatch(removeCompanionWindow(windowId, cw.id));
-    }
-  });
-
   dispatch(deselectAnnotation(windowId));
 }
 
+/** Save the current annotation */
+function saveSelectedAnnotation({ state, windowId }) {
+  const companionWindows = getAnnotationCompanionWindows(state, windowId);
+  if (companionWindows.length === 0) return;
+
+  // dispatch MAE_SAVE_EVENT so AnnotationFormFooter can handle annotation saving
+  document.dispatchEvent(new CustomEvent(MAE_SAVE_EVENT));
+}
+
+/** Escape handler: unselect anno / close companion window */
+function escapeAction({ state, dispatch, windowId }) {
+  const annotationId = getSelectedAnnotationId(state, { windowId });
+
+  if (annotationId) {
+    dispatch(deselectAnnotation(windowId));
+    return;
+  }
+
+  closeAnnotationCompanionWindows(state, dispatch, windowId);
+}
+
 /**
- * Hotkey registry.
- *
  * Maps a keyboard event to an action
  * The action is only performed on the focused Mirador window
  * The handler receives the full Redux state and a dispatch
- * function so it can read any selector and fire any action.
+ * function so it can read any selector and fire any action
  *
  * {
  *   keys:        string[] KeyboardEvent.key values that trigger the action
@@ -60,9 +95,19 @@ function deleteSelectedAnnotation({
  */
 const HOTKEYS = [
   {
-    description: 'Delete selected annotation',
-    handler: deleteSelectedAnnotation,
+    description: 'Delete selected shape or annotation',
+    handler: deleteSelectedShape,
     keys: ['Delete', 'Backspace'],
+  },
+  {
+    description: 'Save current annotation',
+    handler: saveSelectedAnnotation,
+    keys: ['Enter'],
+  },
+  {
+    description: 'Deselect annotation / close companion window',
+    handler: escapeAction,
+    keys: ['Escape'],
   },
 ];
 

--- a/src/hotkeys/hotkeysDefinitions.js
+++ b/src/hotkeys/hotkeysDefinitions.js
@@ -103,27 +103,27 @@ function escapeAction({ state, dispatch, windowId }) {
  *       ctx.config        Mirador config object
  * }
  */
-const HOTKEYS = [
-  {
-    description: 'Delete selected shape or annotation',
-    handler: deleteSelectedShape,
-    keys: ['Delete', 'Backspace'],
-  },
-  {
-    description: 'Save current annotation',
-    handler: saveSelectedAnnotation,
-    keys: ['Enter'],
-  },
-  {
-    description: 'Deselect annotation / close companion window',
-    handler: escapeAction,
-    keys: ['Escape'],
-  },
-  {
+const HOTKEY_ACTIONS = {
+  create: {
     description: 'Create a new annotation',
     handler: createAnnotation,
     keys: ['a'],
   },
-];
+  delete: {
+    description: 'Delete selected shape or annotation',
+    handler: deleteSelectedShape,
+    keys: ['Delete', 'Backspace'],
+  },
+  escape: {
+    description: 'Deselect annotation / close companion window',
+    handler: escapeAction,
+    keys: ['Escape'],
+  },
+  save: {
+    description: 'Save current annotation',
+    handler: saveSelectedAnnotation,
+    keys: ['Enter'],
+  },
+};
 
-export default HOTKEYS;
+export default HOTKEY_ACTIONS;

--- a/src/hotkeys/hotkeysDefinitions.js
+++ b/src/hotkeys/hotkeysDefinitions.js
@@ -1,0 +1,69 @@
+import {
+  deselectAnnotation,
+  getCompanionWindowsForContent,
+  getSelectedAnnotationId,
+  getVisibleCanvases,
+  receiveAnnotation,
+  removeCompanionWindow,
+} from 'mirador';
+
+/** Delete selected annotation on Delete/Backspace */
+function deleteSelectedAnnotation({
+  state, dispatch, windowId, config,
+}) {
+  const annotationId = getSelectedAnnotationId(state, { windowId });
+  if (!annotationId) return;
+
+  const storageAdapter = config?.annotation?.adapter;
+  if (!storageAdapter) return;
+
+  const canvases = getVisibleCanvases(state, { windowId });
+
+  canvases.forEach((canvas) => {
+    const adapter = storageAdapter(canvas.id);
+    adapter.delete(annotationId).then((annoPage) => {
+      dispatch(receiveAnnotation(canvas.id, adapter.annotationPageId, annoPage));
+    });
+  });
+
+  // Close companion window
+  const companionWindows = getCompanionWindowsForContent(state, {
+    content: 'annotationCreation',
+    windowId,
+  });
+  Object.values(companionWindows).forEach((cw) => {
+    if (cw?.id) {
+      dispatch(removeCompanionWindow(windowId, cw.id));
+    }
+  });
+
+  dispatch(deselectAnnotation(windowId));
+}
+
+/**
+ * Hotkey registry.
+ *
+ * Maps a keyboard event to an action
+ * The action is only performed on the focused Mirador window
+ * The handler receives the full Redux state and a dispatch
+ * function so it can read any selector and fire any action.
+ *
+ * {
+ *   keys:        string[] KeyboardEvent.key values that trigger the action
+ *   description:          Human-readable description
+ *   handler:     (ctx) => void
+ *       ctx.state         current Redux state
+ *       ctx.dispatch      Redux dispatch
+ *       ctx.windowId      focused window ID
+ *       ctx.config        Mirador config object
+ * }
+ */
+const HOTKEYS = [
+  {
+    description: 'Delete selected annotation',
+    handler: deleteSelectedAnnotation,
+    keys: ['Delete', 'Backspace'],
+  },
+];
+
+export default HOTKEYS;

--- a/src/hotkeys/hotkeysDefinitions.js
+++ b/src/hotkeys/hotkeysDefinitions.js
@@ -1,4 +1,5 @@
 import {
+  addCompanionWindow,
   deselectAnnotation,
   getCompanionWindowsForContent,
   getSelectedAnnotationId,
@@ -65,6 +66,15 @@ function saveSelectedAnnotation({ state, windowId }) {
   document.dispatchEvent(new CustomEvent(MAE_SAVE_EVENT));
 }
 
+/** Create a new annotation by opening companion window */
+function createAnnotation({ state, dispatch, windowId }) {
+  const companionWindows = getAnnotationCompanionWindows(state, windowId);
+  // Only create if no annotation companion window is already open
+  if (companionWindows.length > 0) return;
+
+  dispatch(addCompanionWindow(windowId, { content: 'annotationCreation', position: 'right' }));
+}
+
 /** Escape handler: unselect anno / close companion window */
 function escapeAction({ state, dispatch, windowId }) {
   const annotationId = getSelectedAnnotationId(state, { windowId });
@@ -108,6 +118,11 @@ const HOTKEYS = [
     description: 'Deselect annotation / close companion window',
     handler: escapeAction,
     keys: ['Escape'],
+  },
+  {
+    description: 'Create a new annotation',
+    handler: createAnnotation,
+    keys: ['a'],
   },
 ];
 

--- a/src/hotkeys/hotkeysEvents.js
+++ b/src/hotkeys/hotkeysEvents.js
@@ -1,0 +1,8 @@
+/** Custom DOM event name used to trigger annotation save from hotkeys */
+export const MAE_SAVE_EVENT = 'mae-save-annotation';
+
+/** Custom DOM event to delete the currently selected shape */
+export const MAE_DELETE_SHAPE_EVENT = 'mae-delete-shape';
+
+/** Dispatched by TargetSpatialInput when the last shape has been removed */
+export const MAE_ANNOTATION_EMPTY_EVENT = 'mae-annotation-empty';

--- a/src/plugins/canvasAnnotationsPlugin.jsx
+++ b/src/plugins/canvasAnnotationsPlugin.jsx
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 import {
   addCompanionWindow,
   addCompanionWindow as addCompanionWindowAction,
+  deselectAnnotation as deselectAnnotationAction,
   getCompanionWindowsForContent,
   getVisibleCanvases,
+  getWindow,
   getWindowViewType,
   receiveAnnotation as receiveAnnotationAction,
   setWindowViewType as setWindowViewTypeAction,
+  updateWindow as updateWindowAction,
 } from 'mirador';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
@@ -18,6 +21,7 @@ import translations from '../locales/locales';
 import {
   scrollToSelectedAnnotation,
 } from './canvasAnnotationsPluginUtils';
+import { useContextParams } from '../contextParams';
 
 // TODO Attention merge M4upstream
 /**
@@ -38,10 +42,13 @@ function CanvasAnnotationsWrapper({
   annotationsOnCanvases = {},
   canvases = [],
   config,
+  deselectAnnotation,
+  highlightAllAnnotations,
   receiveAnnotation,
   switchToSingleCanvasView,
   TargetComponent,
   targetProps,
+  updateWindow,
   windowViewType,
   annotationEditCompanionWindowIsOpened,
 }) {
@@ -96,6 +103,62 @@ function CanvasAnnotationsWrapper({
       }
     }
   }, [config.translations, config.language]);
+
+  const { editMode: isEditMode } = useContextParams(config);
+
+  useEffect(() => {
+    if (isEditMode && !highlightAllAnnotations) {
+      // make all annotations visible when edit mode is active
+      updateWindow({ highlightAllAnnotations: true });
+    }
+  }, [isEditMode, highlightAllAnnotations, updateWindow]);
+
+  const isAnnotationEditable = useCallback((annotationId) => {
+    if (!annotationId) return false;
+    return canvases.some((canvas) => {
+      const anno = annotationsOnCanvases[canvas.id];
+      if (!anno) return false;
+      return Object.values(anno).some((value) => {
+        if (value.json && value.json.items) {
+          // need maeData property for edition
+          return value.json.items.some((item) => item.id === annotationId && item.maeData);
+        }
+        return false;
+      });
+    });
+  }, [canvases, annotationsOnCanvases]);
+
+  const wasCloseCompanionWindowRef = useRef(annotationEditCompanionWindowIsOpened);
+  useEffect(() => {
+    const wasOpen = !wasCloseCompanionWindowRef.current;
+    const isClosed = annotationEditCompanionWindowIsOpened;
+    wasCloseCompanionWindowRef.current = annotationEditCompanionWindowIsOpened;
+
+    // deselect anno when companion window closes (save or close btn)
+    if (isEditMode && wasOpen && isClosed) {
+      deselectAnnotation();
+    }
+  }, [isEditMode, annotationEditCompanionWindowIsOpened, deselectAnnotation]);
+
+  const prevSelectedIdRef = useRef(null);
+  useEffect(() => {
+    if (!isEditMode) return;
+    // auto-open companion window when annotation is selected
+    const selId = targetProps?.selectedAnnotationId;
+
+    if (selId === prevSelectedIdRef.current) return;
+    prevSelectedIdRef.current = selId;
+
+    if (!selId) return;
+    if (!annotationEditCompanionWindowIsOpened) return; // companion window already open
+    if (!isAnnotationEditable(selId)) return;
+
+    addCompanionWindow('annotationCreation', {
+      annotationid: selId,
+      position: 'right',
+    });
+  }, [isEditMode, targetProps?.selectedAnnotationId, annotationEditCompanionWindowIsOpened,
+    isAnnotationEditable, addCompanionWindow]);
 
   const props = {
     containerRef: bridgedScrollRef,
@@ -180,17 +243,21 @@ CanvasAnnotationsWrapper.propTypes = {
   config: PropTypes.shape({
     annotation: PropTypes.shape({
       adapter: PropTypes.func,
+      editMode: PropTypes.bool,
     }),
     language: PropTypes.string,
     // eslint-disable-next-line react/forbid-prop-types
     translations: PropTypes.objectOf(PropTypes.object),
   }).isRequired,
+  deselectAnnotation: PropTypes.func.isRequired,
+  highlightAllAnnotations: PropTypes.bool.isRequired,
   receiveAnnotation: PropTypes.func.isRequired,
   switchToSingleCanvasView: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   TargetComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   targetProps: PropTypes.object.isRequired,
+  updateWindow: PropTypes.func.isRequired,
   windowViewType: PropTypes.string.isRequired,
 };
 
@@ -208,7 +275,6 @@ function mapStateToProps(state, { targetProps: { windowId } }) {
     }
   });
 
-
   // TODO Before merging we were injecting translation inside config.
   //  Perhaps a regression to remove it
   return {
@@ -219,6 +285,7 @@ function mapStateToProps(state, { targetProps: { windowId } }) {
       ...state.config,
       translations,
     },
+    highlightAllAnnotations: getWindow(state, { windowId }).highlightAllAnnotations,
     windowViewType: getWindowViewType(state, { windowId }),
   };
 }
@@ -250,11 +317,17 @@ const mapDispatchToProps = (dispatch, props) => ({
     props.targetProps.windowId,
     { content, ...additionalProps },
   )),
+  deselectAnnotation: () => dispatch(
+    deselectAnnotationAction(props.targetProps.windowId),
+  ),
   receiveAnnotation: (targetId, id, annotation) => dispatch(
     receiveAnnotationAction(targetId, id, annotation),
   ),
   switchToSingleCanvasView: () => dispatch(
     setWindowViewTypeAction(props.targetProps.windowId, 'single'),
+  ),
+  updateWindow: (payload) => dispatch(
+    updateWindowAction(props.targetProps.windowId, payload),
   ),
 });
 const canvasAnnotationsPlugin = {

--- a/src/plugins/externalStorageAnnotationPlugin.jsx
+++ b/src/plugins/externalStorageAnnotationPlugin.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import HotkeysListener from '../hotkeys/HotkeysListener';
 
-// TODO attantion merge
+// TODO attention merge
 
 /** Functional component version of ExternalStorageAnnotation */
 function ExternalStorageAnnotation({
@@ -10,10 +11,13 @@ function ExternalStorageAnnotation({
   targetProps,
 }) {
   return (
-    <TargetComponent
-      {...targetProps} // eslint-disable-line react/jsx-props-no-spreading
-      PluginComponents={PluginComponents}
-    />
+    <>
+      <HotkeysListener />
+      <TargetComponent
+        {...targetProps} // eslint-disable-line react/jsx-props-no-spreading
+        PluginComponents={PluginComponents}
+      />
+    </>
   );
 }
 

--- a/src/plugins/miradorAnnotationPlugin.jsx
+++ b/src/plugins/miradorAnnotationPlugin.jsx
@@ -18,6 +18,7 @@ import SingleCanvasDialog from '../SingleCanvasDialog';
 import AnnotationExportDialog from '../AnnotationExportDialog';
 import LocalStorageAdapter from '../annotationAdapter/LocalStorageAdapter';
 import translations from '../locales/locales';
+import HotkeyTooltip from "../hotkeys/HotkeyTooltip";
 
 const StyledDiv = styled('div')(() => ({
   display: 'flex',
@@ -85,7 +86,7 @@ function MiradorAnnotation(
       <TargetComponent {...targetProps} />
       {
         config?.annotation?.readonly === true ? null : (
-          <Tooltip title={t('create_annotation')}>
+          <Tooltip title={<HotkeyTooltip label={t('create_annotation')} action="create" />}>
             <span>
               <MiradorMenuButton
                 aria-label={t('create_annotation')}

--- a/src/plugins/miradorAnnotationPlugin.jsx
+++ b/src/plugins/miradorAnnotationPlugin.jsx
@@ -161,13 +161,14 @@ MiradorAnnotation.propTypes = {
   windowViewType: PropTypes.string.isRequired,
 };
 
-// TODO use selector in main componenent
+// TODO use selector in main component
 /**
  * this function map the state to the annotationPlugin's props
  * */
 function mapStateToProps(state, { targetProps: { windowId } }) {
   // Annotation edit companion window ou annotation creation companion window is the same thing
   const annotationCreationCompanionWindows = getCompanionWindowsForContent(state, { content: 'annotationCreation', windowId });
+  // TODO variable name is confusing: canOpenEditCompanionWindow? isCompanionWindowOpenable?
   let annotationEditCompanionWindowIsOpened = true;
   if (Object.keys(annotationCreationCompanionWindows).length !== 0) {
     annotationEditCompanionWindowIsOpened = false;


### PR DESCRIPTION
This PR proposes several additions for viewer interaction.

## Keyboard Shortcut

* Introduction of a new module `hotkeys/` with a generic `HotkeyListener`, an extendable `HotkeyDefinitions` registry and custom `hotkeysEvents` to link Redux state and React components
* The listener make sure the user is not focused on an Input or TextArea or Select, then get the currently use window to act in the correct viewer panel and check if target is editable 
* New hotkeys include:
    * `A`: if the annotation form sidebar (companion window) is closed, open it to add new annotation
    * `Backspace` / `Del`: when a shape is selected, delete the shape. If the annotation contains no more shapes, delete the annotation as well and close companion window
    * `Enter`: when the companion window is open, save the annotation
    * `Esc`: unselect selected annotation (if one is selected), then close companion window
* Events allows to use custom HTML events to me dispatched by hotkeys action and listen to by components. The `HotkeysListener` is mounted inside `externalStorageAnnotationPlugin`. Events include:
    * `mae-save-annotation`: when saving an annotation
    * `mae-delete-shape`: when deleting a shape
    * `mae-annotation-empty`: when the last shape associated with an annotation is deleted

## Context configuration with URL search parameters

* `src/contextParams.js` allow to define configuration parameters in URL, if not present, behavior is the same as before. This can be extented
* Available parameters include:
    * `editMode`: when set to `true`, all shape outlines are visible. When hovering an annotation, the outline changes color. On click on the shape, the shape is immediately resizable
    * `defaultForm`: can be set to "note"|"tag"|"expert", when set, the annotation form is automatically selected
    * `defaultTags`: can be set with a list of strings separated by commas. If note form is selected, all the tags are added by default to the annotation. If tag form is selected, only the first tag of the list is added

Test with `http://localhost:4444/demo/src/index.html?editMode=true&defaultForm=note&defaultTags=super,cool`

## Miscellaneous

* Fixed the back button tooltip in `AnnotationFormHeader`
* When switching to a drawing tool (not edit), the current shape is now deselected to prevent unintended edits.
* Removed duplicated code in `AnnotationDrawing` and bit of linting
* Deselect any selected shape when switching to drawing tool (should fix #154)

> NOTE: when drawing multiple shapes for a unique annotation, the outline of the shapes stays as if it was editable (red and 5px thick) even when the companion window is not open. It seems that the issue pre-existed this PR but it became more visible is editMode


