### PR TITLE
Issue #251: add github action to test for dependency errors

### DIFF
--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -3,11 +3,9 @@ name: Test NPM Install
 
 on:
   push:
-    branches:
-      - "**"
+    branches: [ main ]
   pull_request:
-    branches:
-      - "**"
+    branches: [ main ]
   workflow_dispatch: # allows manual triggering
 
 jobs:

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -1,0 +1,28 @@
+# test that the NPM package can be installed properly
+name: Test NPM Install
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: # allows manual triggering
+
+jobs:
+  test-install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Create empty project
+        run: npm init -y
+
+      - name: Test npm install
+        run: npm install mirador-annotation-editor
+
+      - name: Verify package installed
+        run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -3,9 +3,11 @@ name: Test NPM Install
 
 on:
   push:
-    branches: [main, aiiinotate]
+    branches:
+      - "**"
   pull_request:
-    branches: [main, aiiinotate]
+    branches:
+      - "**"
   workflow_dispatch: # allows manual triggering
 
 jobs:
@@ -22,7 +24,7 @@ jobs:
         run: npm init -y
 
       - name: Test npm install
-        run: npm install mirador-annotation-editor
+        run: npm install mirador-annotation-editor@latest
 
       - name: Verify package installed
         run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -26,9 +26,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # assert that the package can be built
       - name: Build package
         run: npm run build
-
-      # node -e defaults to cjs => test cjs import
-      - name: Verify package can be imported
-        run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -22,5 +22,4 @@ jobs:
           node-version: '23'
 
       - name: Install dependencies
-
         run: npm install --omit=dev

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -23,7 +23,3 @@ jobs:
 
       - name: Install dependencies
         run: npm install --omit=dev
-
-      # assert that the package can be built
-      - name: Build package
-        run: npm run build

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -22,4 +22,5 @@ jobs:
           node-version: '23'
 
       - name: Install dependencies
+
         run: npm install --omit=dev

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -22,4 +22,4 @@ jobs:
           node-version: '23'
 
       - name: Install dependencies
-        run: npm install --omit=dev
+        run: npm install # --omit=dev

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -15,16 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Create empty project
-        run: npm init -y
-
-      - name: Test npm install
-        run: npm install mirador-annotation-editor@1.2.4
+      - name: Install dependencies
+        run: npm install
 
       - name: Verify package installed
         run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -3,9 +3,9 @@ name: Test NPM Install
 
 on:
   push:
-    branches: [main]
+    branches: [main, aiiinotate]
   pull_request:
-    branches: [main]
+    branches: [main, aiiinotate]
   workflow_dispatch: # allows manual triggering
 
 jobs:

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -26,5 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Verify package installed
-        run: node -e "import 'mirador-annotation-editor'; console.log('Package loaded successfully!')"
+      - name: Build package
+        run: npm run build
+
+      # node -e defaults to cjs => test cjs import
+      - name: Verify package can be imported
+        run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -24,7 +24,7 @@ jobs:
         run: npm init -y
 
       - name: Test npm install
-        run: npm install mirador-annotation-editor@latest
+        run: npm install mirador-annotation-editor@1.2.4
 
       - name: Verify package installed
         run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -22,7 +22,7 @@ jobs:
           node-version: '23'
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --omit=dev
 
       # assert that the package can be built
       - name: Build package

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -27,4 +27,4 @@ jobs:
         run: npm install
 
       - name: Verify package installed
-        run: node -e "require('mirador-annotation-editor'); console.log('Package loaded successfully!')"
+        run: node -e "import 'mirador-annotation-editor'; console.log('Package loaded successfully!')"

--- a/.github/workflows/test-npm-install.yaml
+++ b/.github/workflows/test-npm-install.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '23'
 
       - name: Install dependencies
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -3647,16 +3647,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@jest/reporters/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11551,16 +11541,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jest-config/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/jest-config/node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
@@ -12145,16 +12125,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/jest-runtime/node_modules/slash": {
@@ -12929,13 +12899,13 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mirador": {
@@ -16424,16 +16394,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/text-table": {


### PR DESCRIPTION
hi @geourjoa 

this is my solution for: https://github.com/TETRAS-IIIF/mirador-annotation-editor/issues/251#issuecomment-4241852721

i added a github action that tests that the `package.json` can be installed successfully.

i can't test the actual NPM package installation because that would need a new version of MAE to be published through NPM before merging the PR, which would be a big/weird change to your current workflow.

thanks !