### PR TITLE
Fix scaling/zoom issue for annotation targets on image manifests

### DIFF
--- a/__tests__/playerReferences.test.js
+++ b/__tests__/playerReferences.test.js
@@ -1,0 +1,55 @@
+import { WindowPlayer } from '../src/playerReferences';
+
+vi.mock('mirador', () => ({
+  getVisibleCanvasAudioResources: vi.fn().mockReturnValue([]),
+  getVisibleCanvases: vi.fn().mockReturnValue([{
+    __jsonld: { height: 6000, width: 8000 },
+  }]),
+  getVisibleCanvasVideoResources: vi.fn().mockReturnValue([]),
+}));
+
+/**
+ * Build a fake OpenSeadragon viewer whose TiledImage reports a displayed
+ * size unrelated to the image's true pixel dimensions or a naive
+ * `containerWidth * zoom` guess, so any regression to the old hand-rolled
+ * formula (which multiplied in the true pixel size an extra time) would be
+ * caught by asserting the exact mocked value is returned untouched.
+ */
+function createViewer({ displayedWidth = 300, displayedHeight = 225 } = {}) {
+  const tiledImage = {
+    getSizeInWindowCoordinates: vi.fn().mockReturnValue({
+      x: displayedWidth,
+      y: displayedHeight,
+    }),
+  };
+  return {
+    canvas: { clientHeight: 900, clientWidth: 1200 },
+    container: { clientWidth: 1200 },
+    // intentionally wrong/misleading, to prove they are no longer consulted
+    viewport: { getZoom: vi.fn().mockReturnValue(0.15) },
+    world: {
+      getItemAt: vi.fn().mockReturnValue(tiledImage),
+      getItemCount: vi.fn().mockReturnValue(1),
+    },
+  };
+}
+
+describe('WindowPlayer displayed media size', () => {
+  it('derives displayed width/height from OpenSeadragon TiledImage#getSizeInWindowCoordinates, not from true-pixel-size * zoom', () => {
+    const viewer = createViewer({ displayedHeight: 225, displayedWidth: 300 });
+    const player = new WindowPlayer({}, 'window-1', { current: viewer }, {});
+
+    expect(player.getDisplayedMediaWidth()).toBe(300);
+    expect(player.getDisplayedMediaHeight()).toBe(225);
+    // the old buggy formula was `containerWidth * trueWidth * zoom` = 1200 * 8000 * 0.15
+    expect(player.getDisplayedMediaWidth()).not.toBe(Math.round(1200 * 8000 * 0.15));
+  });
+
+  it('a small image (true size close to container size) still reflects the viewer-reported size exactly', () => {
+    const viewer = createViewer({ displayedHeight: 400, displayedWidth: 400 });
+    const player = new WindowPlayer({}, 'window-1', { current: viewer }, {});
+
+    expect(player.getDisplayedMediaWidth()).toBe(400);
+    expect(player.getDisplayedMediaHeight()).toBe(400);
+  });
+});

--- a/__tests__/stripSpuriousWhiteBackgroundRect.test.js
+++ b/__tests__/stripSpuriousWhiteBackgroundRect.test.js
@@ -1,0 +1,37 @@
+import { stripSpuriousWhiteBackgroundRect } from '../src/annotationForm/AnnotationFormOverlay/KonvaDrawing/KonvaUtils';
+
+describe('stripSpuriousWhiteBackgroundRect', () => {
+  it('removes a strokeless opaque-white rect (the svgcanvas clearRect artifact)', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+      + '<rect x="0" y="0" width="100" height="100" fill="#FFFFFF"/>'
+      + '<rect x="10" y="10" width="20" height="20" fill="rgba(100,100,100,0)" stroke="rgb(255,0,0)"/>'
+      + '</svg>';
+
+    const cleaned = stripSpuriousWhiteBackgroundRect(svg);
+
+    expect(cleaned).not.toContain('#FFFFFF');
+    expect(cleaned).toContain('stroke="rgb(255,0,0)"');
+  });
+
+  it('leaves shapes alone when none match the artifact signature', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">'
+      + '<rect x="1" y="1" width="10" height="10" fill="rgba(100,100,100,0)" stroke="rgb(255,0,0)"/>'
+      + '</svg>';
+
+    const cleaned = stripSpuriousWhiteBackgroundRect(svg);
+
+    expect(cleaned).toContain('stroke="rgb(255,0,0)"');
+    expect((cleaned.match(/<rect/g) || []).length).toBe(1);
+  });
+
+  it('is case-insensitive and tolerant of the "white" and "#fff" spellings', () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="30" height="30">'
+      + '<rect x="0" y="0" width="30" height="30" fill="white"/>'
+      + '<rect x="0" y="0" width="30" height="30" fill="#fff"/>'
+      + '</svg>';
+
+    const cleaned = stripSpuriousWhiteBackgroundRect(svg);
+
+    expect((cleaned.match(/<rect/g) || []).length).toBe(0);
+  });
+});

--- a/src/annotationForm/AnnotationFormOverlay/KonvaDrawing/KonvaUtils.js
+++ b/src/annotationForm/AnnotationFormOverlay/KonvaDrawing/KonvaUtils.js
@@ -97,6 +97,33 @@ export function showKonvaStage() {
 }
 
 /**
+ * `exportStageSVG` (via the `svgcanvas` shim it uses to record Konva's canvas draw calls
+ * as SVG) draws an opaque white `<rect>` covering the whole stage whenever it sees a
+ * `clearRect` call under a non-identity transform matrix. Konva's per-layer `clear()` ends
+ * up in exactly that situation whenever the browser's `devicePixelRatio` isn't 1 (i.e. any
+ * retina/high-DPI screen), since the pixel-ratio scale is still applied to the transform at
+ * that point. This bakes a stray opaque white box into every exported annotation target on
+ * such screens (see issue #267).
+ *
+ * Real annotation shapes always get an explicit `stroke` set by `cleanNode` below, so a
+ * strokeless, opaque-white `<rect>` can only be this export artifact, never user content -
+ * safe to strip.
+ * @param {string} svg
+ * @returns {string}
+ */
+export function stripSpuriousWhiteBackgroundRect(svg) {
+  const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  doc.querySelectorAll('rect').forEach((rect) => {
+    const fill = (rect.getAttribute('fill') || '').trim().toLowerCase();
+    const isOpaqueWhite = fill === '#ffffff' || fill === '#fff' || fill === 'white';
+    if (isOpaqueWhite && !rect.hasAttribute('stroke')) {
+      rect.remove();
+    }
+  });
+  return new XMLSerializer().serializeToString(doc.documentElement);
+}
+
+/**
  * Get SVG picture containing all the stuff draw in the stage (Konva Stage).
  * This image will be put in overlay of the iiif media
  */
@@ -146,6 +173,7 @@ export async function getSvg(windowId) {
     });
 
   let svg = await exportStageSVG(stage, false); // TODO clean
+  svg = stripSpuriousWhiteBackgroundRect(svg);
   svg = svg.replaceAll('"', '\'');
   return svg;
 }

--- a/src/playerReferences.js
+++ b/src/playerReferences.js
@@ -170,16 +170,21 @@ export class WindowPlayer {
 
   /**
    * Get displayed height of the media. It include zoom and scale stuff
+   *
+   * NOTE: uses OpenSeadragon's TiledImage#getSizeInWindowCoordinates(), which converts the
+   * image's true pixel dimensions to on-screen container pixels while correctly accounting
+   * for zoom/pan/rotation. A previous hand-rolled formula (`containerWidth * trueHeight * zoom`)
+   * multiplied in the true pixel dimension an extra, spurious time, producing wildly wrong
+   * sizes for images whose true pixel dimensions differ a lot from the container size
+   * (see issue #267).
    * @returns {undefined|*|number}
    */
   getDisplayedMediaHeight() {
     if (this.mediaType === MEDIA_TYPES.IMAGE) {
       const viewer = this.media.current;
-      if (viewer) {
-        const percentageHeight = this.getMediaTrueHeight() * viewer.viewport.getZoom();
-        const containerWidth = viewer.container.clientWidth;
-        const actualHeightInPixels = Math.round(containerWidth * percentageHeight);
-        return actualHeightInPixels;
+      if (viewer && viewer.world.getItemCount() > 0) {
+        const tiledImage = viewer.world.getItemAt(0);
+        return Math.round(tiledImage.getSizeInWindowCoordinates().y);
       }
     }
     return undefined;
@@ -193,10 +198,8 @@ export class WindowPlayer {
     if (this.mediaType === MEDIA_TYPES.IMAGE) {
       const viewer = this.media.current;
       if (viewer && viewer.world.getItemCount() > 0) {
-        const percentageWidth = this.getMediaTrueWidth() * viewer.viewport.getZoom();
-        const containerWidth = viewer.container.clientWidth;
-        const actualWidthInPixels = Math.round(containerWidth * percentageWidth);
-        return actualWidthInPixels;
+        const tiledImage = viewer.world.getItemAt(0);
+        return Math.round(tiledImage.getSizeInWindowCoordinates().x);
       }
     }
     return undefined;


### PR DESCRIPTION
## Summary
Fixes #267 — two distinct, independent bugs were causing the reported symptoms.

### 1. Wrong scale/size on images whose true pixel dimensions differ a lot from the container
`WindowPlayer#getDisplayedMediaWidth()` / `getDisplayedMediaHeight()` computed the on-screen size of the image as:

```
displayed = containerWidth * trueImagePixelSize * zoom
```

That formula multiplies in the true IIIF pixel dimension (e.g. 8000 for the Pogacar manifest in the issue) an extra, spurious time — OpenSeadragon's `zoom` already relates `containerWidth` to the displayed size directly, without needing the true pixel size at all. This fed straight into the Konva stage sizing (`AnnotationDrawing.jsx`), the interactive draw-layer scale (`TargetSpatialInput.jsx` / `ParentComponent.jsx`), and the exported IIIF target coordinates (`IIIFUtils.js`). The bug's visibility depended on how far an image's true pixel dimensions were from typical container sizes, matching the issue's report that a 400×400 test image looked fine while an 8000×6000 scan (Pogacar) and the Gauguin/Harvard manifest broke. This exact formula had been patched reactively at least twice before in the repo's history without ever being made dimensionally correct.

**Fix**: replaced the hand-rolled zoom math with OpenSeadragon's own supported API, `TiledImage#getSizeInWindowCoordinates()`, which does this conversion correctly and isn't sensitive to how a given OSD version internally normalizes viewport bounds.

### 2. Unwanted white background box on the exported annotation target
Independently of the scale bug, saved annotation SVG targets could come out with a stray opaque white rectangle baked in (reported on the Pogacar manifest). Root cause: `getSvg()` (`KonvaUtils.js`) exports the Konva stage to SVG via `react-konva-to-svg`, which swaps each layer's real 2D context for the `svgcanvas` recording shim before calling `stage.draw()`. Konva's own `Context.reset()` sets the transform to `(pixelRatio, 0, 0, pixelRatio, 0, 0)` using the canvas's real screen pixel ratio before every draw. On any screen where `devicePixelRatio !== 1` (most retina/high-DPI displays), that transform isn't the identity matrix, so `svgcanvas`'s `clearRect` fast path (a true, invisible clear) never triggers — it falls back to drawing an actual opaque `<rect fill="#FFFFFF">` over the canvas to emulate "clearing" it. That rect ends up baked into the SVG selector used as the annotation's target.

**Fix**: rather than patch Konva/`svgcanvas` internals (fragile, relies on private state), strip this artifact from the exported SVG string in `getSvg()`. Real annotation shapes always get an explicit `stroke` forced onto them by `cleanNode` a few lines above, so any strokeless, opaque-white `<rect>` in the output can only be this export artifact, never user content — safe to remove.

## Test plan
- [x] Added `__tests__/playerReferences.test.js` — unit tests `getDisplayedMediaWidth`/`getDisplayedMediaHeight` against a mocked OpenSeadragon viewer, asserting the value comes from `TiledImage#getSizeInWindowCoordinates()` and not the old buggy formula.
- [x] Added `__tests__/stripSpuriousWhiteBackgroundRect.test.js` — unit tests the SVG-cleanup helper against the exact artifact signature (`svgcanvas`'s hardcoded `fill="#FFFFFF"`, no stroke) plus a couple of near-miss/negative cases.
- [x] `npx vitest run` — same pre-existing failures as on `main` (`LocalStorageAdapter.test.js`, a `localStorage` environment issue unrelated to this change), no new failures.
- [x] `npm run lint` — no new lint errors introduced (verified line-by-line against `main`; repo has pre-existing lint debt unrelated to these files).
- [ ] Manual visual verification in the MAE demo against the Gauguin/Harvard and Pogacar manifests from the issue — not done here (no browser available in this environment); please verify visually before merging, ideally on a retina/high-DPI screen for the white-background fix specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)